### PR TITLE
Allow unrented event to use placeholders

### DIFF
--- a/AreaShop/src/main/java/me/wiefferink/areashop/regions/RentRegion.java
+++ b/AreaShop/src/main/java/me/wiefferink/areashop/regions/RentRegion.java
@@ -672,10 +672,10 @@ public class RentRegion extends GeneralRegion {
 		}
 
 		// Broadcast and check event
-		UnrentingRegionEvent event = new UnrentingRegionEvent(this);
-		Bukkit.getPluginManager().callEvent(event);
-		if(event.isCancelled()) {
-			message(executor, "general-cancelled", event.getReason());
+		UnrentingRegionEvent unrentingRegionEvent = new UnrentingRegionEvent(this);
+		Bukkit.getPluginManager().callEvent(unrentingRegionEvent);
+		if(unrentingRegionEvent.isCancelled()) {
+			message(executor, "general-cancelled", unrentingRegionEvent.getReason());
 			return false;
 		}
 
@@ -729,13 +729,17 @@ public class RentRegion extends GeneralRegion {
 		// Remove friends, the owner and renteduntil values
 		getFriendsFeature().clearFriends();
 		UUID oldRenter = getRenter();
-		setRenter(null);
 		setRentedUntil(null);
 		setTimesExtended(-1);
 		removeLastActiveTime();
 
 		// Notify about updates
-		this.notifyAndUpdate(new UnrentedRegionEvent(this, oldRenter, Math.max(0, moneyBack)));
+		Bukkit.getPluginManager().callEvent(new UnrentedRegionEvent(this, oldRenter, Math.max(0, moneyBack)));
+		// Placed here so when event is passed, the player renting can still be accessed
+		setRenter(null);
+		// Update world (has to be after setting renter to null)
+		this.update();
+
 		return true;
 	}
 

--- a/AreaShop/src/main/resources/default.yml
+++ b/AreaShop/src/main/resources/default.yml
@@ -179,6 +179,9 @@ general:
     extended:
       before:
       after:
+    unrenting:
+      before:
+      after:
     unrented:
       before:
       after:

--- a/AreaShop/src/main/resources/default.yml
+++ b/AreaShop/src/main/resources/default.yml
@@ -179,9 +179,6 @@ general:
     extended:
       before:
       after:
-    unrenting:
-      before:
-      after:
     unrented:
       before:
       after:


### PR DESCRIPTION
Fixes issue #11 by setting renter to null after calling UnrentedRegionEvent.

Let me know if anything needs to be changed here.

Thanks,
Cleo (she/her)